### PR TITLE
Replace GKE ClusterAdmin with GKE Admin role

### DIFF
--- a/infrastructure/cloud/120-gha-deployment-sa.tf
+++ b/infrastructure/cloud/120-gha-deployment-sa.tf
@@ -18,7 +18,7 @@ resource "google_organization_iam_member" "gha-arikkfir-deployment" {
 resource "google_project_iam_member" "gha-arikkfir-deployment" {
   for_each = toset([
     "roles/browser",
-    "roles/container.clusterAdmin",
+    "roles/container.admin",
     "roles/compute.admin",
     "roles/iam.serviceAccountAdmin",
     "roles/resourcemanager.projectIamAdmin",


### PR DESCRIPTION
This is required so that the GitHub Actions service account can actually interact with cluster objects, not just create/update/delete the cluster.